### PR TITLE
Use env vars to configure credentials and certs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ EXPOSE 8080
 
 WORKDIR /app
 
-CMD ["./cmd/imap", "test", "test"]
+CMD ["./cmd/imap"]

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ It can be self-hosted to deliver mails to a local mailbox which
 can be accessed by any IMAP client inside the respective LAN.
 
 ## Usage
-The project is currently in its early stages and is not yet suitable for production use. 
-To run the application, it is recommended to use Docker with the provided Dockerfile. 
-You can specify your username and password as the first and second arguments of the `CMD` instruction in the Dockerfile. 
-Please note that this setup is intended for testing purposes only, as it is not secure. 
-This approach will be updated in the future.
+The project is currently in its early stages and is not yet ready for production use. 
+It is recommended to use Docker with the provided Dockerfile to run the application. 
+You can configure your username, password, certificates, and keys through the following environment variables:
 
+```
+USERNAME=yourusername
+PASSWORD=yourpassword
+CERTIFICATE_PATH=/path/to/certificate
+KEY_PATH=/path/to/key
+```
 
 ## Planned Features
 - [ ] Deliver mails to IMAP clients inside the LAN

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/JaKu01/LocalMail"
 	"github.com/JaKu01/LocalMail/db"
-	imap2 "github.com/JaKu01/LocalMail/imap"
 	"github.com/JaKu01/LocalMail/web"
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	username, password := os.Args[1], os.Args[2]
+	username, password := os.Getenv("USERNAME"), os.Getenv("PASSWORD")
 
 	database, err := gorm.Open(sqlite.Open("db/sqlite/database.db"), &gorm.Config{})
 	if err != nil {
@@ -30,7 +30,7 @@ func main() {
 		log.Panic("username and password required")
 	}
 
-	memServer, server := imap2.CreateServer(true)
+	memServer, server := LocalMail.CreateServer(true)
 	imapUser := imapmemserver.NewUser(username, password)
 	memServer.AddUser(imapUser)
 	err = imapUser.Create("INBOX", &imap.CreateOptions{})
@@ -44,7 +44,7 @@ func main() {
 	fmt.Fprintf(os.Stdout, "Server started for %v\n", username)
 
 	go web.StartWebAPI(imapUser, database)
-	imap2.RunServer(server)
+	LocalMail.RunServer(server)
 }
 
 func loadExistingMails(user *imapmemserver.User, username string, database *gorm.DB) {

--- a/imap.go
+++ b/imap.go
@@ -1,4 +1,4 @@
-package imap
+package LocalMail
 
 import (
 	"crypto/tls"
@@ -24,7 +24,7 @@ func loadTLSConfig(config *tls.Config, tlsCert string, tlsKey string) {
 
 func CreateServer(insecureAuth bool) (*imapmemserver.Server, *imapserver.Server) {
 	var tlsConfig *tls.Config
-	loadTLSConfig(tlsConfig, "", "")
+	loadTLSConfig(tlsConfig, os.Getenv("CERTPATH"), os.Getenv("KEYPATH"))
 
 	memServer := imapmemserver.New()
 


### PR DESCRIPTION
The following environment variables can be used to configure credentials and certs:

```
USERNAME=yourusername
PASSWORD=yourpassword
CERTIFICATE_PATH=/path/to/certificate
KEY_PATH=/path/to/key
```